### PR TITLE
Enable testnet deploys and generation of client secret files

### DIFF
--- a/create_app.sh
+++ b/create_app.sh
@@ -11,6 +11,10 @@ DEPLOY=$APPNAME.deploy
 STORAGENAME=$(echo -n $APPNAME | sed -e 's/-/_/g')_data
 REGION=iad
 
+# select testnet or mainnet
+echo "Do you want to run on testnet or mainnet"
+read MOB_CHAIN
+
 # get fly org interactively
 echo "What fly.io organization to use?"
 read FLY_ORG
@@ -21,8 +25,13 @@ read FLY_ORG
 mkdir -p $DEPLOY
 cat fly.toml | sed -e "s/rose-gadget-abstract-high/$APPNAME/" | sed -e "s/rose_gadget_abstract_high_data/$STORAGENAME/" > $DEPLOY/fly.toml
 cp Dockerfile stunnel.docker.conf run.sh $DEPLOY/
-mv $APPNAME.secrets $DEPLOY/
+mv $APPNAME.secrets $APPNAME.clientsecrets $DEPLOY/
+if [[ "$MOB_CHAIN" == testnet ]]; then
+    cp run-test.sh $DEPLOY/run.sh
+fi
 
+# set the chain target
+sed -i "s/mainnet/$MOB_CHAIN/g" $DEPLOY/Dockerfile
 
 # do the deploy on Fly
 cd $DEPLOY

--- a/create_keychain.sh
+++ b/create_keychain.sh
@@ -59,6 +59,7 @@ set +x
 echo "ROOTCRT=$(cat $output/rootcrt.pem | gzip - | base64 --wrap=0)" > $name.secrets
 echo "SERVERCRT=$(cat $output/server.full.pem | gzip - | base64 --wrap=0)" >> $name.secrets
 
+echo "ROOTCRT=" > $name.clientsecrets && base64 $output/rootcrt.pem >> $name.clientsecrets && echo "CLIENTCRT=" >> $name.clientsecrets && base64 $output/client.full.pem >> $name.clientsecrets && sed -i ':a;N;$!ba;s/\n//g' $name.clientsecrets && sed -i "s/CLIENTCRT/\nCLIENTCRT/g" $name.clientsecrets
 ## might be needed for stunnel verif=3
 #rm -f *.0 || true
 #ln -s rootcrt.pem $(openssl x509 -hash -noout -in rootcrt.pem).0

--- a/run-test.sh
+++ b/run-test.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+echo $ROOTCRT | base64 -d | gzip -d > cacert.pem
+echo $SERVERCRT | base64 -d | gzip -d > servercert.pem
+set -exu
+stunnel stunnel.conf &
+./full-service \
+  --wallet-db /data/wallet.db \
+  --ledger-db /data/ledger-db/ \
+  --peer mc://node1.test.mobilecoin.com/ \
+  --peer mc://node2.test.mobilecoin.com/ \
+  --tx-source-url https://s3-us-west-1.amazonaws.com/mobilecoin.chain/node1.test.mobilecoin.com/ \
+  --tx-source-url https://s3-us-west-1.amazonaws.com/mobilecoin.chain/node2.test.mobilecoin.com/ \
+  --fog-ingest-enclave-css ./ingest-enclave.css \
+  --listen-host 127.0.0.1


### PR DESCRIPTION
This PR
*Enable deploys of testnet instances
*Creates a secrets file that can be used in client secret files